### PR TITLE
Fix alt text for Torgarr image

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
         <div class="container">
             <h2 id="about">The Orc that started it all!</h2>
             <div class="img-container">
-                <img src="./resources/images/torgarr.png" aria-label="Photo of Torgar in all his laughing glory">
+                <img src="./resources/images/torgarr.png" alt="Photo of Torgarr in all his laughing glory">
             </div>
             <div class="container">
                 <h3>Torgarr</h3>


### PR DESCRIPTION
## Summary
- correct Torgarr image tag attribute

## Testing
- `grep -n torgarr.png -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_687a3fc1796c832a812f384867347f11